### PR TITLE
Make vmware_guest always get a resource pool

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1484,9 +1484,9 @@ class PyVmomiHelper(PyVmomi):
         else:
             vm_obj = None
 
-        # need a resource pool if cloning from template
-        if self.params['resource_pool'] or self.params['template']:
-            resource_pool = self.get_resource_pool()
+        resource_pool = None
+        # always get a resource_pool
+        resource_pool = self.get_resource_pool()
 
         # set the destination datastore for VM & disks
         (datastore, datastore_name) = self.select_datastore(vm_obj)
@@ -1562,7 +1562,6 @@ class PyVmomiHelper(PyVmomi):
                                                         vmPathName="[" + datastore_name + "]")
 
                 clone_method = 'CreateVM_Task'
-                resource_pool = self.get_resource_pool()
                 try:
                     task = destfolder.CreateVM_Task(config=self.configspec, pool=resource_pool)
                 except vmodl.fault.InvalidRequest as e:


### PR DESCRIPTION
##### SUMMARY
Small change to the code to always get a resource pool before the 'template'/'no-template' code where it would be called anyway.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
vmware_guest

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```